### PR TITLE
Adds minimal TypeScript types

### DIFF
--- a/dist/types/audiokeys.d.ts
+++ b/dist/types/audiokeys.d.ts
@@ -1,0 +1,26 @@
+type AudioKeysOptions = {
+  polyphony: number
+  rows: 1 | 2
+  priority: 'last' | 'first' | 'highest' | 'lowest'
+  rootNote: number
+  octaveControls: boolean
+  velocityControls: boolean
+}
+
+interface AudioKeysNoteData {
+  velocity: number // the velocity, between 0 and 127
+  keyCode: number // the keyboard key pressed or released
+  note: number
+  frequency: number
+  isActive: boolean
+}
+
+declare module 'audiokeys' {
+  export default class AudioKeysDefault {
+    constructor(options: Partial<AudioKeysOptions>)
+    up(callback: (note: AudioKeysNoteData) => void): void
+    down(callback: (note: AudioKeysNoteData) => void): void
+    clear: () => void
+  }
+  export class AudioKeys extends AudioKeysDefault {}
+}

--- a/dist/types/audiokeys.d.ts
+++ b/dist/types/audiokeys.d.ts
@@ -17,7 +17,7 @@ interface AudioKeysNoteData {
 
 declare module 'audiokeys' {
   export default class AudioKeysDefault {
-    constructor(options: Partial<AudioKeysOptions>)
+    constructor(options?: Partial<AudioKeysOptions>)
     up(callback: (note: AudioKeysNoteData) => void): void
     down(callback: (note: AudioKeysNoteData) => void): void
     clear: () => void

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "type" : "git",
     "url" : "https://github.com/kylestetz/AudioKeys.git"
   },
+  "types": "dist/types/audiokeys.d.ts",
   "keywords": [
     "web audio",
     "audio",

--- a/src/AudioKeys.js
+++ b/src/AudioKeys.js
@@ -64,3 +64,4 @@ AudioKeys.prototype._specialKeyMap = special._specialKeyMap;
 // Browserify will take care of making this a global
 // in a browser environment without a build system.
 module.exports = AudioKeys;
+module.exports.AudioKeys = AudioKeys;


### PR DESCRIPTION
Also provides AudioKeys as a named export to enable TypeScript [module augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation).